### PR TITLE
Add startTime to Pattern

### DIFF
--- a/Pattern/doc/spec.md
+++ b/Pattern/doc/spec.md
@@ -49,6 +49,10 @@ A JSON Schema corresponding to this data model can be found [here](../schema.jso
         -   `{{metadata Property name}}` : {{Metadata Property Description}}
     -   Mandatory
 
+-   `startTime` : The time at which the pattern starts
+    -   Attribute type: `Property`. [Time](https://schema.org/Time)
+    -   Mandatory
+
 ### Pattern Entity Relationships
 No defined Relationships for this Entity.
 

--- a/Pattern/example-normalized-ld.csv
+++ b/Pattern/example-normalized-ld.csv
@@ -1,2 +1,2 @@
-"id", "type", "createdAt", "modifiedAt", "multipliers__value", "multipliers__unitCode", "timeStep__value", "timeStep__unitCode", "description__value", "tag__value", "@context"
-"urn:ngsi-ld:Pattern:fbcb5fc8-8ca3-4533-a2eb-34bc89262190", "Pattern", "2020-02-20T17:43:00Z", "2020-02-20T17:43:00Z", "[0.5692, 0.4647, 0.4385, 0.3604, 0.3098, 0.3345]", "C62", "3600", "SEC", "Open Text", "DMA1", "['https://schema.lab.fiware.org/ld/context']"
+"id", "type", "createdAt", "modifiedAt", "multipliers__value", "multipliers__unitCode", "timeStep__value", "timeStep__unitCode", "description__value", "startTime__value", "tag__value", "@context"
+"urn:ngsi-ld:Pattern:fbcb5fc8-8ca3-4533-a2eb-34bc89262190", "Pattern", "2020-02-20T17:43:00Z", "2020-02-20T17:43:00Z", "[0.5692, 0.4647, 0.4385, 0.3604, 0.3098, 0.3345]", "C62", "3600", "SEC", "Open Text", "00:00", "DMA1", "['https://schema.lab.fiware.org/ld/context']"

--- a/Pattern/example-normalized-ld.jsonld
+++ b/Pattern/example-normalized-ld.jsonld
@@ -17,6 +17,10 @@
         "type": "Property",
         "value": "Open Text"
     },
+    "startTime": {
+        "type": "Property",
+        "value": "00:00"
+    },
     "tag": {
         "type": "Property",
         "value": "DMA1"

--- a/Pattern/schema.json
+++ b/Pattern/schema.json
@@ -21,6 +21,9 @@
                 "timeStep": {
                     "$ref": "../WaterNetworkManagement-schema.json#/definitions/ngsildProperty"
                 },
+                "startTime": {
+                    "$ref": "../WaterNetworkManagement-schema.json#/definitions/ngsildProperty"
+                },
                 "description": {
                     "$ref": "../WaterNetworkManagement-schema.json#/definitions/ngsildProperty"
                 },
@@ -34,6 +37,7 @@
         "id",
         "type",
         "multipliers",
-        "timeStep"
+        "timeStep",
+        "startTime"
     ]
 }


### PR DESCRIPTION
It is necessary to know what time a pattern starts at (defined with the project-wide `EN_PATTERNSTART` time parameter in EPANET). Add a `startTime` attribute to `Pattern` entities to give this information.