### PR TITLE
Feature/add link vertices

### DIFF
--- a/Pipe/doc/spec.md
+++ b/Pipe/doc/spec.md
@@ -108,7 +108,7 @@ A JSON Schema corresponding to this data model can be found [here](../schema.jso
         -   `{{metadata Property name}}` : {{Metadata Property Description}}
     -   Optional
 
--   `vertices` : Coordinates of all vertices in the pipe, ordered from the `startsAt` node to the `endsAt` node and encoded as a GeoJSON `LineString`.
+-   `vertices` : Coordinates of all vertices in the pipe, ordered from the `startsAt` node to the `endsAt` node and encoded as a GeoJSON `LineString` or `Point`.
     -   Attribute type: `GeoProperty`
     -   Normative References:
         [https://tools.ietf.org/html/rfc7946](https://tools.ietf.org/html/rfc7946)

--- a/Pipe/doc/spec.md
+++ b/Pipe/doc/spec.md
@@ -108,6 +108,12 @@ A JSON Schema corresponding to this data model can be found [here](../schema.jso
         -   `{{metadata Property name}}` : {{Metadata Property Description}}
     -   Optional
 
+-   `vertices` : Coordinates of all vertices in the pipe, ordered from the `startsAt` node to the `endsAt` node and encoded as a GeoJSON `LineString`.
+    -   Attribute type: `GeoProperty`
+    -   Normative References:
+        [https://tools.ietf.org/html/rfc7946](https://tools.ietf.org/html/rfc7946)
+    -   Optional
+
 
 ### Pipe Entity Relationships
 

--- a/Pipe/doc/spec.md
+++ b/Pipe/doc/spec.md
@@ -108,7 +108,7 @@ A JSON Schema corresponding to this data model can be found [here](../schema.jso
         -   `{{metadata Property name}}` : {{Metadata Property Description}}
     -   Optional
 
--   `vertices` : Coordinates of all vertices in the pipe, ordered from the `startsAt` node to the `endsAt` node and encoded as a GeoJSON `LineString` or `Point`.
+-   `vertices` : Coordinates of all vertices in the pipe, ordered from the `startsAt` node to the `endsAt` node and encoded as a GeoJSON `MultiPoint` or `Point`.
     -   Attribute type: `GeoProperty`
     -   Normative References:
         [https://tools.ietf.org/html/rfc7946](https://tools.ietf.org/html/rfc7946)

--- a/Pipe/examples/example-normalized.jsonld
+++ b/Pipe/examples/example-normalized.jsonld
@@ -50,7 +50,7 @@
     "vertices": {
         "type": "GeoProperty",
         "value": {
-            "type": "LineString",
+            "type": "MultiPoint",
             "coordinates": [
                 [24.40623, 60.17966],
                 [24.50623, 60.27966]

--- a/Pipe/examples/example-normalized.jsonld
+++ b/Pipe/examples/example-normalized.jsonld
@@ -47,6 +47,16 @@
         "type": "Relationship",
         "object": "urn:ngsi-ld:Reservoir:1863179e-3768-4480-9167-ff21f870dd19"
     },
+    "vertices": {
+        "type": "GeoProperty",
+        "value": {
+            "type": "LineString",
+            "coordinates": [
+                [24.40623, 60.17966],
+                [24.50623, 60.27966]
+            ]
+        }
+    },
     "bulkCoeff":{
         "type": "Property",
         "value": 72.4549,

--- a/Pipe/schema.json
+++ b/Pipe/schema.json
@@ -49,7 +49,14 @@
           "$ref": "https://raw.githubusercontent.com/smart-data-models/dataModel.WaterNetworkManagement/master/WaterNetworkManagement-schema.json#/definitions/ngsildProperty"
         },
         "vertices": {
-          "$ref": "http://geojson.org/schema/Geometry.json#LineString"
+          "oneOf": [
+              {
+                  "$ref": "http://geojson.org/schema/Geometry.json#LineString"
+              },
+              {
+                  "$ref": "http://geojson.org/schema/Geometry.json#Point"
+              }
+          ]                    
         }
       }
     }

--- a/Pipe/schema.json
+++ b/Pipe/schema.json
@@ -47,6 +47,9 @@
         },
         "bulkCoeff": {
           "$ref": "https://raw.githubusercontent.com/smart-data-models/dataModel.WaterNetworkManagement/master/WaterNetworkManagement-schema.json#/definitions/ngsildProperty"
+        },
+        "vertices": {
+          "$ref": "http://geojson.org/schema/Geometry.json#LineString"
         }
       }
     }

--- a/Pipe/schema.json
+++ b/Pipe/schema.json
@@ -51,7 +51,7 @@
         "vertices": {
           "oneOf": [
               {
-                  "$ref": "http://geojson.org/schema/Geometry.json#LineString"
+                  "$ref": "http://geojson.org/schema/Geometry.json#MultiPoint"
               },
               {
                   "$ref": "http://geojson.org/schema/Geometry.json#Point"

--- a/Pump/doc/spec.md
+++ b/Pump/doc/spec.md
@@ -80,7 +80,7 @@ A JSON Schema corresponding to this data model can be found [here](../schema.jso
         -   `{{metadata Property name}}` : {{Metadata Property Description}}
     -   Optional
 
--   `vertices` : Coordinates of all vertices in the pump, ordered from the `startsAt` node to the `endsAt` node and encoded as a GeoJSON `LineString` or `Point`.
+-   `vertices` : Coordinates of all vertices in the pump, ordered from the `startsAt` node to the `endsAt` node and encoded as a GeoJSON `MultiPoint` or `Point`.
     -   Attribute type: `GeoProperty`
     -   Normative References:
         [https://tools.ietf.org/html/rfc7946](https://tools.ietf.org/html/rfc7946)

--- a/Pump/doc/spec.md
+++ b/Pump/doc/spec.md
@@ -80,6 +80,12 @@ A JSON Schema corresponding to this data model can be found [here](../schema.jso
         -   `{{metadata Property name}}` : {{Metadata Property Description}}
     -   Optional
 
+-   `vertices` : Coordinates of all vertices in the pump, ordered from the `startsAt` node to the `endsAt` node and encoded as a GeoJSON `LineString`.
+    -   Attribute type: `GeoProperty`
+    -   Normative References:
+        [https://tools.ietf.org/html/rfc7946](https://tools.ietf.org/html/rfc7946)
+    -   Optional
+
 ### Pump Entity Relationships
 
 -   `startsAt` : The ID of the node on the suction side of the pump

--- a/Pump/doc/spec.md
+++ b/Pump/doc/spec.md
@@ -80,7 +80,7 @@ A JSON Schema corresponding to this data model can be found [here](../schema.jso
         -   `{{metadata Property name}}` : {{Metadata Property Description}}
     -   Optional
 
--   `vertices` : Coordinates of all vertices in the pump, ordered from the `startsAt` node to the `endsAt` node and encoded as a GeoJSON `LineString`.
+-   `vertices` : Coordinates of all vertices in the pump, ordered from the `startsAt` node to the `endsAt` node and encoded as a GeoJSON `LineString` or `Point`.
     -   Attribute type: `GeoProperty`
     -   Normative References:
         [https://tools.ietf.org/html/rfc7946](https://tools.ietf.org/html/rfc7946)

--- a/Pump/examples/example-normalized.jsonld
+++ b/Pump/examples/example-normalized.jsonld
@@ -29,6 +29,16 @@
         "type": "Relationship",
         "object": "urn:ngsi-ld:Reservoir:1863179e-3768-4480-9167-ff21f870dd19"
     },
+    "vertices": {
+        "type": "GeoProperty",
+        "value": {
+            "type": "LineString",
+            "coordinates": [
+                [24.40623, 60.17966],
+                [24.50623, 60.27966]
+            ]
+        }
+    },
     "tag": {
         "type": "Property",
         "value": "DMA1"

--- a/Pump/examples/example-normalized.jsonld
+++ b/Pump/examples/example-normalized.jsonld
@@ -32,7 +32,7 @@
     "vertices": {
         "type": "GeoProperty",
         "value": {
-            "type": "LineString",
+            "type": "MultiPoint",
             "coordinates": [
                 [24.40623, 60.17966],
                 [24.50623, 60.27966]

--- a/Pump/schema.json
+++ b/Pump/schema.json
@@ -33,6 +33,9 @@
                 "endsAt": {
                     "$ref": "https://raw.githubusercontent.com/smart-data-models/dataModel.WaterNetworkManagement/master/WaterNetworkManagement-schema.json#/definitions/ngsildRelationship"
                 },
+                "vertices": {
+                    "$ref": "http://geojson.org/schema/Geometry.json#LineString"
+                },
                 "tag": {
                     "$ref": "https://raw.githubusercontent.com/smart-data-models/dataModel.WaterNetworkManagement/master/WaterNetworkManagement-schema.json#/definitions/ngsildProperty"
                 },

--- a/Pump/schema.json
+++ b/Pump/schema.json
@@ -34,7 +34,14 @@
                     "$ref": "https://raw.githubusercontent.com/smart-data-models/dataModel.WaterNetworkManagement/master/WaterNetworkManagement-schema.json#/definitions/ngsildRelationship"
                 },
                 "vertices": {
-                    "$ref": "http://geojson.org/schema/Geometry.json#LineString"
+                    "oneOf": [
+                        {
+                            "$ref": "http://geojson.org/schema/Geometry.json#LineString"
+                        },
+                        {
+                            "$ref": "http://geojson.org/schema/Geometry.json#Point"
+                        }
+                    ]                    
                 },
                 "tag": {
                     "$ref": "https://raw.githubusercontent.com/smart-data-models/dataModel.WaterNetworkManagement/master/WaterNetworkManagement-schema.json#/definitions/ngsildProperty"

--- a/Pump/schema.json
+++ b/Pump/schema.json
@@ -36,7 +36,7 @@
                 "vertices": {
                     "oneOf": [
                         {
-                            "$ref": "http://geojson.org/schema/Geometry.json#LineString"
+                            "$ref": "http://geojson.org/schema/Geometry.json#MultiPoint"
                         },
                         {
                             "$ref": "http://geojson.org/schema/Geometry.json#Point"

--- a/Valve/doc/spec.md
+++ b/Valve/doc/spec.md
@@ -85,6 +85,13 @@ A JSON Schema corresponding to this data model can be found [here](../schema.jso
     -   Attribute metadata Properties:
         -   `{{metadata Property name}}` : {{Metadata Property Description}}
     -   Mandatory
+
+-   `vertices` : Coordinates of all vertices in the valve, ordered from the `startsAt` node to the `endsAt` node and encoded as a GeoJSON `LineString`.
+    -   Attribute type: `GeoProperty`
+    -   Normative References:
+        [https://tools.ietf.org/html/rfc7946](https://tools.ietf.org/html/rfc7946)
+    -   Optional
+
 ### Valve Entity Relationships
 
 -   `startsAt` : The ID of the node on the nominal upstream or inflow side of the valve

--- a/Valve/doc/spec.md
+++ b/Valve/doc/spec.md
@@ -86,7 +86,7 @@ A JSON Schema corresponding to this data model can be found [here](../schema.jso
         -   `{{metadata Property name}}` : {{Metadata Property Description}}
     -   Mandatory
 
--   `vertices` : Coordinates of all vertices in the valve, ordered from the `startsAt` node to the `endsAt` node and encoded as a GeoJSON `LineString`.
+-   `vertices` : Coordinates of all vertices in the valve, ordered from the `startsAt` node to the `endsAt` node and encoded as a GeoJSON `LineString` or `Point`.
     -   Attribute type: `GeoProperty`
     -   Normative References:
         [https://tools.ietf.org/html/rfc7946](https://tools.ietf.org/html/rfc7946)

--- a/Valve/doc/spec.md
+++ b/Valve/doc/spec.md
@@ -86,7 +86,7 @@ A JSON Schema corresponding to this data model can be found [here](../schema.jso
         -   `{{metadata Property name}}` : {{Metadata Property Description}}
     -   Mandatory
 
--   `vertices` : Coordinates of all vertices in the valve, ordered from the `startsAt` node to the `endsAt` node and encoded as a GeoJSON `LineString` or `Point`.
+-   `vertices` : Coordinates of all vertices in the valve, ordered from the `startsAt` node to the `endsAt` node and encoded as a GeoJSON `MultiPoint` or `Point`.
     -   Attribute type: `GeoProperty`
     -   Normative References:
         [https://tools.ietf.org/html/rfc7946](https://tools.ietf.org/html/rfc7946)

--- a/Valve/examples/example-normalized.jsonld
+++ b/Valve/examples/example-normalized.jsonld
@@ -42,6 +42,16 @@
         "type": "Relationship",
         "object": "urn:ngsi-ld:Reservoir:1863179e-3768-4480-9167-ff21f870dd19"
     },
+    "vertices": {
+        "type": "GeoProperty",
+        "value": {
+            "type": "LineString",
+            "coordinates": [
+                [24.40623, 60.17966],
+                [24.50623, 60.27966]
+            ]
+        }
+    },
     "@context": [
         "https://schema.lab.fiware.org/ld/context"
     ]

--- a/Valve/examples/example-normalized.jsonld
+++ b/Valve/examples/example-normalized.jsonld
@@ -45,7 +45,7 @@
     "vertices": {
         "type": "GeoProperty",
         "value": {
-            "type": "LineString",
+            "type": "MultiPoint",
             "coordinates": [
                 [24.40623, 60.17966],
                 [24.50623, 60.27966]

--- a/Valve/schema.json
+++ b/Valve/schema.json
@@ -43,7 +43,14 @@
                     "$ref": "https://raw.githubusercontent.com/smart-data-models/dataModel.WaterNetworkManagement/master/WaterNetworkManagement-schema.json#/definitions/ngsildRelationship"
                 },
                 "vertices": {
-                    "$ref": "http://geojson.org/schema/Geometry.json#LineString"
+                    "oneOf": [
+                        {
+                            "$ref": "http://geojson.org/schema/Geometry.json#LineString"
+                        },
+                        {
+                            "$ref": "http://geojson.org/schema/Geometry.json#Point"
+                        }
+                    ]                    
                 }
             }
         }

--- a/Valve/schema.json
+++ b/Valve/schema.json
@@ -41,6 +41,9 @@
                 },
                 "endsAt": {
                     "$ref": "https://raw.githubusercontent.com/smart-data-models/dataModel.WaterNetworkManagement/master/WaterNetworkManagement-schema.json#/definitions/ngsildRelationship"
+                },
+                "vertices": {
+                    "$ref": "http://geojson.org/schema/Geometry.json#LineString"
                 }
             }
         }

--- a/Valve/schema.json
+++ b/Valve/schema.json
@@ -45,7 +45,7 @@
                 "vertices": {
                     "oneOf": [
                         {
-                            "$ref": "http://geojson.org/schema/Geometry.json#LineString"
+                            "$ref": "http://geojson.org/schema/Geometry.json#MultiPoint"
                         },
                         {
                             "$ref": "http://geojson.org/schema/Geometry.json#Point"


### PR DESCRIPTION
Add a `vertices` GeoProperty to pipes, pumps and valves. Allow vertices to be a LineString (used when a link has multiple vertices) or Point (used when a link has one vertex).