### PR TITLE
Fix the Name of the properties "demand" and source in the WaterNetwor…

### DIFF
--- a/Junction/schema.json
+++ b/Junction/schema.json
@@ -21,7 +21,7 @@
                     "$ref": "https://raw.githubusercontent.com/smart-data-models/dataModel.WaterNetworkManagement/master/WaterNetworkManagement-schema.json#/definitions/ngsildProperty"
                 },
                 "demandCategory": {
-                    "$ref": "https://raw.githubusercontent.com/smart-data-models/dataModel.WaterNetworkManagement/master/WaterNetworkManagement-schema.json/definitions/demand"
+                    "$ref": "https://raw.githubusercontent.com/smart-data-models/dataModel.WaterNetworkManagement/master/WaterNetworkManagement-schema.json/definitions/demandCategory"
                 },
                 "tag": {
                     "$ref": "https://raw.githubusercontent.com/smart-data-models/dataModel.WaterNetworkManagement/master/WaterNetworkManagement-schema.json#/definitions/ngsildProperty"
@@ -36,7 +36,7 @@
                     "$ref": "https://raw.githubusercontent.com/smart-data-models/dataModel.WaterNetworkManagement/master/WaterNetworkManagement-schema.json#/definitions/ngsildProperty"
                 },
                 "sourceCategory": {
-                    "$ref": "https://raw.githubusercontent.com/smart-data-models/dataModel.WaterNetworkManagement/master/WaterNetworkManagement-schema.json#/definitions/source"
+                    "$ref": "https://raw.githubusercontent.com/smart-data-models/dataModel.WaterNetworkManagement/master/WaterNetworkManagement-schema.json#/definitions/sourceCategory"
                 }
             }
         }

--- a/Reservoir/schema.json
+++ b/Reservoir/schema.json
@@ -36,10 +36,10 @@
                     "$ref": "https://raw.githubusercontent.com/smart-data-models/dataModel.WaterNetworkManagement/master/WaterNetworkManagement-schema.json#/definitions/ngsildProperty"
                 },
                 "demandCategory": {
-                    "$ref": "https://raw.githubusercontent.com/smart-data-models/dataModel.WaterNetworkManagement/master/WaterNetworkManagement-schema.json#/definitions/demand"
+                    "$ref": "https://raw.githubusercontent.com/smart-data-models/dataModel.WaterNetworkManagement/master/WaterNetworkManagement-schema.json#/definitions/demandCategory"
                 },
                 "sourceCategory": {
-                    "$ref": "https://raw.githubusercontent.com/smart-data-models/dataModel.WaterNetworkManagement/master/WaterNetworkManagement-schema.json#/definitions/source"
+                    "$ref": "https://raw.githubusercontent.com/smart-data-models/dataModel.WaterNetworkManagement/master/WaterNetworkManagement-schema.json#/definitions/sourceCategory"
                 },
                 "headPattern": {
                      "$ref": "https://raw.githubusercontent.com/smart-data-models/dataModel.WaterNetworkManagement/master/WaterNetworkManagement-schema.json#/definitions/ngsildRelationship"

--- a/Tank/schema.json
+++ b/Tank/schema.json
@@ -51,10 +51,10 @@
                     "$ref": "https://raw.githubusercontent.com/smart-data-models/dataModel.WaterNetworkManagement/master/WaterNetworkManagement-schema.json#/definitions/ngsildProperty"
                 },
                 "baseDemand": {
-                    "$ref": "https://raw.githubusercontent.com/smart-data-models/dataModel.WaterNetworkManagement/master/WaterNetworkManagement-schema.json#/definitions/demand"
+                    "$ref": "https://raw.githubusercontent.com/smart-data-models/dataModel.WaterNetworkManagement/master/WaterNetworkManagement-schema.json#/definitions/baseDemand"
                 },
                 "sourceCategory": {
-                    "$ref": "https://raw.githubusercontent.com/smart-data-models/dataModel.WaterNetworkManagement/master/WaterNetworkManagement-schema.json#/definitions/source"
+                    "$ref": "https://raw.githubusercontent.com/smart-data-models/dataModel.WaterNetworkManagement/master/WaterNetworkManagement-schema.json#/definitions/sourceCategory"
                 },
                 "volumeCurve": {
                     "$ref": "https://raw.githubusercontent.com/smart-data-models/dataModel.WaterNetworkManagement/master/WaterNetworkManagement-schema.json#/definitions/ngsildRelationship"

--- a/WaterNetworkManagement-schema.json
+++ b/WaterNetworkManagement-schema.json
@@ -118,7 +118,7 @@
                 "value"
             ]
         },
-        "demand": {
+        "demandCategory": {
             "type": "object",
             "properties": {
                 "type": {
@@ -225,7 +225,7 @@
                 "demandPattern"
             ]
         },
-        "source": {
+        "sourceCategory": {
             "type": "object",
             "properties": {
                 "type": {


### PR DESCRIPTION
Fix the Name of the properties "demand" and "source" in the WaterNetworkManagement-schema to follow the used ones in the payloads "demandCategory" and "sourceCategory".
Fix then their URL in the schemas of Junction, Reservoir and Tank.
