### PR TITLE
Add/fix missing property descriptions

### DIFF
--- a/Curve/doc/spec.md
+++ b/Curve/doc/spec.md
@@ -47,6 +47,10 @@ A JSON Schema corresponding to this data model can be found [here](../schema.jso
         -   `{{metadata Property name}}` : {{Metadata Property Description}}
     -   Mandatory
 
+-   `tag` : An optional text string used to assign the curve to a category.
+    -   Attribute type: `Property`.Text
+    -   Optional
+
 ### Junction Entity Relationships
 
 No Relationhips defined for this entity

--- a/Pattern/doc/spec.md
+++ b/Pattern/doc/spec.md
@@ -11,7 +11,7 @@ A JSON Schema corresponding to this data model can be found [here](../schema.jso
 
 -   `id`: Unique identifier.
 
--   `type`: Entity type. It must be equal to `Junction`.
+-   `type`: Entity type. It must be equal to `Pattern`.
 
 -   `modifiedAt`: Last update timestamp of this
     entity.
@@ -25,7 +25,7 @@ A JSON Schema corresponding to this data model can be found [here](../schema.jso
     -   Read-Only. Automatically generated.
 
  ### Pattern Entity Properties
--   `tag` : An optional text string used to assign the junction to a category, such as a pressure zone
+-   `tag` : An optional text string used to assign the pattern to a category, such as a pressure zone
     -   Attribute type: `Property`.Text
     -   Optional
 

--- a/Pipe/doc/spec.md
+++ b/Pipe/doc/spec.md
@@ -11,7 +11,7 @@ A JSON Schema corresponding to this data model can be found [here](../schema.jso
 ### NGSI-LD common Properties
 -   `id`: Unique identifier.
 
--   `type`: Entity type. It must be equal to `PIPE`.
+-   `type`: Entity type. It must be equal to `Pipe`.
 
 -   `modifiedAt`: Last update timestamp of this
     entity.
@@ -24,7 +24,7 @@ A JSON Schema corresponding to this data model can be found [here](../schema.jso
     -   Attribute type: Property. [DateTime](https://schema.org/DateTime)
     -   Read-Only. Automatically generated.
 
--   `location` : Location of Junction represented by a GeoJSON geometry.
+-   `location` : Location of Pipe represented by a GeoJSON geometry.
 
     -   Attribute type: `GeoProperty`
     -   Normative References:

--- a/Pump/doc/spec.md
+++ b/Pump/doc/spec.md
@@ -10,7 +10,7 @@ A JSON Schema corresponding to this data model can be found [here](../schema.jso
 ### NGSI-LD common Properties
 -   `id`: Unique identifier.
 
--   `type`: Entity type. It must be equal to `Junction`.
+-   `type`: Entity type. It must be equal to `Pump`.
 
 -   `modifiedAt`: Last update timestamp of this
     entity.
@@ -23,7 +23,7 @@ A JSON Schema corresponding to this data model can be found [here](../schema.jso
     -   Attribute type: Property. [DateTime](https://schema.org/DateTime)
     -   Read-Only. Automatically generated.
 
--   `location` : Location of Junction represented by a GeoJSON geometry.
+-   `location` : Location of Pump represented by a GeoJSON geometry.
 
     -   Attribute type: `GeoProperty`
     -   Normative References:

--- a/Reservoir/doc/spec.md
+++ b/Reservoir/doc/spec.md
@@ -10,7 +10,7 @@ A JSON Schema corresponding to this data model can be found [here](../schema.jso
 ## NGSI-LD Common Properties
 -   `id`: Unique identifier.
 
--   `type`: Entity type. It must be equal to `Junction`.
+-   `type`: Entity type. It must be equal to `Reservoir`.
 
 -   `modifiedAt`: Last update timestamp of this
     entity.
@@ -23,7 +23,7 @@ A JSON Schema corresponding to this data model can be found [here](../schema.jso
     -   Attribute type: Property. [DateTime](https://schema.org/DateTime)
     -   Read-Only. Automatically generated.
 
--   `location` : Location of Junction represented by a GeoJSON geometry.
+-   `location` : Location of Reservoir represented by a GeoJSON geometry.
 
     -   Attribute type: `GeoProperty`
     -   Normative References:

--- a/Reservoir/schema.json
+++ b/Reservoir/schema.json
@@ -27,17 +27,11 @@
                 "description": {
                     "$ref": "https://raw.githubusercontent.com/smart-data-models/dataModel.WaterNetworkManagement/master/WaterNetworkManagement-schema.json#/definitions/ngsildProperty"
                 },
-                "emitterCoefficient": {
-                    "$ref": "https://raw.githubusercontent.com/smart-data-models/dataModel.WaterNetworkManagement/master/WaterNetworkManagement-schema.json#/definitions/ngsildProperty"
-                },
                 "elevation": {
                     "$ref": "https://raw.githubusercontent.com/smart-data-models/dataModel.WaterNetworkManagement/master/WaterNetworkManagement-schema.json#/definitions/ngsildProperty"
                 },
                 "tag": {
                     "$ref": "https://raw.githubusercontent.com/smart-data-models/dataModel.WaterNetworkManagement/master/WaterNetworkManagement-schema.json#/definitions/ngsildProperty"
-                },
-                "demandCategory": {
-                    "$ref": "https://raw.githubusercontent.com/smart-data-models/dataModel.WaterNetworkManagement/master/WaterNetworkManagement-schema.json#/definitions/demandCategory"
                 },
                 "sourceCategory": {
                     "$ref": "https://raw.githubusercontent.com/smart-data-models/dataModel.WaterNetworkManagement/master/WaterNetworkManagement-schema.json#/definitions/sourceCategory"

--- a/Tank/doc/spec.md
+++ b/Tank/doc/spec.md
@@ -145,7 +145,7 @@ A JSON Schema corresponding to this data model can be found [here](../schema.jso
         -   `{{metadata Property name}}` : {{Metadata Property Description}}
     -   Mandatory
 
--   `initialQuality` : Water quality level int the tank at the start of the simulation
+-   `initialQuality` : Water quality level in the tank at the start of the simulation
     -   Attribute type: `Property`. Number
     -   Attribute unit: All units are accepted in [CEFACT](https://www.unece.org/cefact.html) code
     -   Attribute unit Example: `mg/L`

--- a/Tank/doc/spec.md
+++ b/Tank/doc/spec.md
@@ -10,7 +10,7 @@ A JSON Schema corresponding to this data model can be found [here](../schema.jso
 ### NGSI-LD common Properties
 -   `id`: Unique identifier.
 
--   `type`: Entity type. It must be equal to `Junction`.
+-   `type`: Entity type. It must be equal to `Tank`.
 
 -   `modifiedAt`: Last update timestamp of this
     entity.
@@ -23,7 +23,7 @@ A JSON Schema corresponding to this data model can be found [here](../schema.jso
     -   Attribute type: Property. [DateTime](https://schema.org/DateTime)
     -   Read-Only. Automatically generated.
 
--   `location` : Location of Junction represented by a GeoJSON geometry.
+-   `location` : Location of Tank represented by a GeoJSON geometry.
 
     -   Attribute type: `GeoProperty`
     -   Normative References:
@@ -88,6 +88,15 @@ A JSON Schema corresponding to this data model can be found [here](../schema.jso
         -   `{{metadata Property name}}` : {{Metadata Property Description}}
     -   Mandatory
 
+-   `minLevel` : The minimum level that water in the tank can drop to
+    -   Attribute type: `Property`. Number
+    -   Attribute unit: All units are accepted in [CEFACT](https://www.unece.org/cefact.html) code
+    -   Attribute unit Example: `metre`
+    -   [CEFACT](https://www.unece.org/cefact.html) unitCode: `MTR`
+    -   Attribute metadata Properties:
+        -   `{{metadata Property name}}` : {{Metadata Property Description}}
+    -   Mandatory
+
 -   `minVolume` : The volume of water in the tank when it is at its minimum level
     -   Attribute type: `Property`. Number
     -   Attribute unit: All units are accepted in [CEFACT](https://www.unece.org/cefact.html) code
@@ -123,6 +132,24 @@ A JSON Schema corresponding to this data model can be found [here](../schema.jso
     -   Attribute unit: All units are accepted in [CEFACT](https://www.unece.org/cefact.html) code
     -   Attribute unit Example:: `No unit`
     -   [CEFACT](https://www.unece.org/cefact.html) unitCode: `C62`
+    -   Attribute metadata Properties:
+        -   `{{metadata Property name}}` : {{Metadata Property Description}}
+    -   Optional
+
+-   `bulkReactionCoefficient` : The bulk reaction coefficient used for modelling reactions in the tank.
+    -   Attribute type: `Property`. Number
+    -   Attribute unit: All units are accepted in [CEFACT](https://www.unece.org/cefact.html) code
+    -   Attribute unit Example: `1/day`
+    -   [CEFACT](https://www.unece.org/cefact.html) unitCode: `E91`
+    -   Attribute metadata Properties:
+        -   `{{metadata Property name}}` : {{Metadata Property Description}}
+    -   Mandatory
+
+-   `initialQuality` : Water quality level int the tank at the start of the simulation
+    -   Attribute type: `Property`. Number
+    -   Attribute unit: All units are accepted in [CEFACT](https://www.unece.org/cefact.html) code
+    -   Attribute unit Example: `mg/L`
+    -   [CEFACT](https://www.unece.org/cefact.html) unitCode: `M1`
     -   Attribute metadata Properties:
         -   `{{metadata Property name}}` : {{Metadata Property Description}}
     -   Optional

--- a/Tank/schema.json
+++ b/Tank/schema.json
@@ -51,9 +51,6 @@
                 "tag": {
                     "$ref": "https://raw.githubusercontent.com/smart-data-models/dataModel.WaterNetworkManagement/master/WaterNetworkManagement-schema.json#/definitions/ngsildProperty"
                 },
-                "baseDemand": {
-                    "$ref": "https://raw.githubusercontent.com/smart-data-models/dataModel.WaterNetworkManagement/master/WaterNetworkManagement-schema.json#/definitions/baseDemand"
-                },
                 "sourceCategory": {
                     "$ref": "https://raw.githubusercontent.com/smart-data-models/dataModel.WaterNetworkManagement/master/WaterNetworkManagement-schema.json#/definitions/sourceCategory"
                 },

--- a/Valve/doc/spec.md
+++ b/Valve/doc/spec.md
@@ -10,7 +10,7 @@ A JSON Schema corresponding to this data model can be found [here](../schema.jso
 ### NGSI-LD common Properties
 -   `id`: Unique identifier.
 
--   `type`: Entity type. It must be equal to `Junction`.
+-   `type`: Entity type. It must be equal to `Valve`.
 
 -   `modifiedAt`: Last update timestamp of this
     entity.
@@ -23,7 +23,7 @@ A JSON Schema corresponding to this data model can be found [here](../schema.jso
     -   Attribute type: Property. [DateTime](https://schema.org/DateTime)
     -   Read-Only. Automatically generated.
 
--   `location` : Location of Junction represented by a GeoJSON geometry.
+-   `location` : Location of Valve represented by a GeoJSON geometry.
 
     -   Attribute type: `GeoProperty`
     -   Normative References:


### PR DESCRIPTION
* Add `tag` description in spec.md for Curve.
* Correct `tag` description in spec.md for Pattern.
* Remove `demandCategory` from Reservoir schema (since EPANET only allows demands to be specified for junctions)
* Remove `emitterCoefficient` from Reservoir schema (since EPANET only allows emitters to be specified for junctions)
* Remove `baseDemand` from Tank schema (baseDemand should be a sub-property of demandCategory, which isn't (and shouldn't) be present for tanks)
* Add `bulkReactionCofficient` description in spec.md for Tank
* Add `initialQuality` description in spec.md for Tank
* Add `minLevel` description in spec.md for Tank.
* Correct `type` description in spec.md for Tank, Valve, Reservoir, Pump and Pattern
* Correct `location` description in spec.md for Tank, Valve, Reservoir, Pump and Pipe