### PR TITLE
fix: sourceCategory is missing a value property 

### DIFF
--- a/WaterNetworkManagement-schema.json
+++ b/WaterNetworkManagement-schema.json
@@ -39,6 +39,9 @@
       "type": "object",
       "description": "Property. Model:'https://schema.org/Text'. Description of the quality of source flow entering the network at a specific node.",
       "properties": {
+          "value": {
+            "type": "string"
+          },
         "sourceType": {
           "type": "string",
           "description": "Property. Model:'https://schema.org/Text'. A sub-property of the Property 'sourceCategory'",


### PR DESCRIPTION
When trying to validate an object derived from `Tank/schema.json` against `Tank/examples/example.json`  the `sourceCategory.value`  in the example is being rejected. ( my model based on `Tank/schema.json` is configured to reject extra fields. 
 `sourceCategory.value` is not defined in schema by adding as per this PR, my model tests pass.

I Have not assessed other examples in `Tank` or other schema/model definitions in Tank